### PR TITLE
Small refactoring and simplification 

### DIFF
--- a/content/reader.go
+++ b/content/reader.go
@@ -2,10 +2,11 @@ package content
 
 import (
 	"encoding/json"
-	uuidutils "github.com/Financial-Times/uuid-utils-go"
-	"github.com/pkg/errors"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/pkg/errors"
+	"github.com/Financial-Times/uuid-utils-go"
 	"github.com/Financial-Times/transactionid-utils-go"
 )
 

--- a/content/reader_test.go
+++ b/content/reader_test.go
@@ -59,7 +59,7 @@ func TestContentReader_Get(t *testing.T) {
 	err = json.Unmarshal(b, &expected)
 	assert.NoError(t, err, "Cannot read expected response for test case.")
 
-	actual, err := cr.Get(testData)
+	actual, err := cr.Get(testData, "tid_1")
 	assert.NoError(t, err, "Error while getting content data")
 	assert.Equal(t, expected, actual)
 }
@@ -70,7 +70,7 @@ func TestContentReader_Get_ContentSourceReturns500(t *testing.T) {
 
 	cr := readerForTest(ts.URL, "/content")
 
-	_, err := cr.Get(testData)
+	_, err := cr.Get(testData, "tid_1")
 	assert.Error(t, err, "There should an error thrown")
 }
 
@@ -80,21 +80,21 @@ func TestContentReader_Get_ContentSourceReturns404(t *testing.T) {
 
 	cr := readerForTest(ts.URL, "/content")
 
-	_, err := cr.Get(testData)
+	_, err := cr.Get(testData, "tid_1")
 	assert.Error(t, err, "There should an error thrown")
 }
 
 func TestContentReader_Get_ContentSourceCannotBeResolved(t *testing.T) {
 	cr := readerForTest("http://sampleAddress:8080", "/content")
 
-	_, err := cr.Get(testData)
+	_, err := cr.Get(testData, "tid_1")
 	assert.Error(t, err, "There should an error thrown")
 }
 
 func TestContentReader_Get_ContentSourceHasInvalidURL(t *testing.T) {
 	cr := readerForTest("&&^%&&^", "@$@")
 
-	_, err := cr.Get(testData)
+	_, err := cr.Get(testData, "tid_1")
 	assert.Error(t, err, "There should an error thrown")
 }
 

--- a/content/service.go
+++ b/content/service.go
@@ -103,7 +103,7 @@ func (ir *ImageResolver) UnrollImages(req UnrollEvent) UnrollResult {
 		return UnrollResult{req.c, nil}
 	}
 
-	imgMap, err := ir.reader.Get(is.toArray())
+	imgMap, err := ir.reader.Get(is.toArray(), req.tid)
 	if err != nil {
 		return UnrollResult{req.c, errors.Wrapf(err, "Error while getting expanded images for uuid:%v", req.uuid)}
 	}
@@ -140,6 +140,10 @@ func (ir *ImageResolver) UnrollLeadImages(req UnrollEvent) UnrollResult {
 		return UnrollResult{req.c, nil}
 	}
 
+	if len(images) == 0 {
+		logger.Info(req.tid, req.uuid, "No lead images to expand for supplied content")
+		return UnrollResult{req.c, nil}
+	}
 	b := make(ImageSchema)
 	for _, item := range images {
 		li := item.(map[string]interface{})
@@ -152,7 +156,7 @@ func (ir *ImageResolver) UnrollLeadImages(req UnrollEvent) UnrollResult {
 		b.put(leadImages, uuid)
 	}
 
-	imgMap, err := ir.reader.Get(b.toArray())
+	imgMap, err := ir.reader.Get(b.toArray(), req.tid)
 	if err != nil {
 		return UnrollResult{req.c, errors.Wrapf(err, "Error while getting content for expanded images uuid:%v", req.uuid)}
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -88,6 +88,7 @@ func TestShouldReturn200ForContentImages(t *testing.T) {
 	body, err := ioutil.ReadFile("test-resources/valid-article.json")
 	assert.NoError(t, err, "Cannot read file necessary for test case")
 	resp, err := http.Post(imageResolver.URL+"/content/image", "application/json", bytes.NewReader(body))
+	assert.NoError(t, err, "Should not fail")
 	defer resp.Body.Close()
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -108,6 +109,7 @@ func TestShouldReturn200ForInternalContentImages(t *testing.T) {
 	body, err := ioutil.ReadFile("test-resources/valid-article-internalcontent.json")
 	assert.NoError(t, err, "Cannot read file necessary for test case")
 	resp, err := http.Post(imageResolver.URL+"/internalcontent/image", "application/json", bytes.NewReader(body))
+	assert.NoError(t, err, "Should not fail")
 	defer resp.Body.Close()
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)

--- a/test-resources/valid-article-internalcontent-no-lead-images.json
+++ b/test-resources/valid-article-internalcontent-no-lead-images.json
@@ -1,0 +1,35 @@
+{
+  "accessLevel": "subscribed",
+  "annotations": [],
+  "apiUrl": "http://api.ft.com/internalcontent/5010e2e4-09bd-11e7-97d1-5e720a26771b",
+  "byline": "Duncan Robinson in The Hague",
+  "canBeDistributed": "yes",
+  "canBeSyndicated": "yes",
+  "comments": {
+    "enabled": true
+  },
+  "id": "http://www.ft.com/thing/5010e2e4-09bd-11e7-97d1-5e720a26771b",
+  "identifiers": [
+    {
+      "authority": "http://api.ft.com/system/FTCOM-METHODE",
+      "identifierValue": "5010e2e4-09bd-11e7-97d1-5e720a26771b"
+    }
+  ],
+  "lastModified": "2017-03-31T08:23:44.909Z",
+  "leadImages": [
+  ],
+  "prefLabel": "Dutch voters crush hopes of populist Wilders",
+  "publishReference": "tid_8pqiiuxbvz",
+  "publishedDate": "2017-03-16T08:37:45.000Z",
+  "requestUrl": "http://api.ft.com/internalcontent/5010e2e4-09bd-11e7-97d1-5e720a26771b",
+  "standfirst": "sample standfirst",
+  "standout": {
+    "editorsChoice": false,
+    "exclusive": false,
+    "scoop": false
+  },
+  "title": "",
+  "types": [
+    "http://www.ft.com/ontology/content/Article"
+  ]
+}

--- a/test-resources/valid-expanded-internalcontent-response-no-lead-images.json
+++ b/test-resources/valid-expanded-internalcontent-response-no-lead-images.json
@@ -1,0 +1,35 @@
+{
+  "accessLevel": "subscribed",
+  "annotations": [],
+  "apiUrl": "http://api.ft.com/internalcontent/5010e2e4-09bd-11e7-97d1-5e720a26771b",
+  "byline": "Duncan Robinson in The Hague",
+  "canBeDistributed": "yes",
+  "canBeSyndicated": "yes",
+  "comments": {
+    "enabled": true
+  },
+  "id": "http://www.ft.com/thing/5010e2e4-09bd-11e7-97d1-5e720a26771b",
+  "identifiers": [
+    {
+      "authority": "http://api.ft.com/system/FTCOM-METHODE",
+      "identifierValue": "5010e2e4-09bd-11e7-97d1-5e720a26771b"
+    }
+  ],
+  "lastModified": "2017-03-31T08:23:44.909Z",
+  "leadImages": [
+  ],
+  "prefLabel": "Dutch voters crush hopes of populist Wilders",
+  "publishReference": "tid_8pqiiuxbvz",
+  "publishedDate": "2017-03-16T08:37:45.000Z",
+  "requestUrl": "http://api.ft.com/internalcontent/5010e2e4-09bd-11e7-97d1-5e720a26771b",
+  "standfirst": "sample standfirst",
+  "standout": {
+    "editorsChoice": false,
+    "exclusive": false,
+    "scoop": false
+  },
+  "title": "",
+  "types": [
+    "http://www.ft.com/ontology/content/Article"
+  ]
+}


### PR DESCRIPTION
If there are no lead images, no request is made to CPR. Tid is propagated to requests to CPR. User-agent is set as well.